### PR TITLE
[FIX] Stored-XSS application-wide

### DIFF
--- a/app/Helpers/AuditLogHelper.php
+++ b/app/Helpers/AuditLogHelper.php
@@ -31,17 +31,16 @@ class AuditLogHelper
                         'logs.settings_log_'.$log->action.'_with_name_with_link',
                         [
                             'link' => '/people/'.$contact->hashId(),
-                            'name' => $contact->name,
+                            'name' => htmlentities($contact->name, ENT_QUOTES, 'utf-8'),
                         ]
                     );
                 } catch (ModelNotFoundException $e) {
                     // the contact doesn't exist anymore, we don't need a link, we'll only display a name
-                    $description = trans('logs.settings_log_'.$log->action.'_with_name', ['name' => $log->object->{'contact_name'}]);
+                    $description = trans('logs.settings_log_'.$log->action.'_with_name', ['name' =>  htmlentities($log->object->{'contact_name'}, ENT_QUOTES, 'utf-8')]);
                 }
             } else {
                 $description = trans('logs.settings_log_'.$log->action, ['name' => $log->object->{'name'}]);
             }
-
             $logsCollection->push([
                 'author_name' => ($log->author) ? $log->author->name : $log->author_name,
                 'description' => $description,

--- a/app/Helpers/AuditLogHelper.php
+++ b/app/Helpers/AuditLogHelper.php
@@ -39,7 +39,7 @@ class AuditLogHelper
                     $description = trans('logs.settings_log_'.$log->action.'_with_name', ['name' =>  htmlentities($log->object->{'contact_name'}, ENT_QUOTES, 'utf-8')]);
                 }
             } else {
-                $description = trans('logs.settings_log_'.$log->action, ['name' => $log->object->{'name'}]);
+                $description = trans('logs.settings_log_'.$log->action, ['name' => htmlentities($log->object->{'name'}, ENT_QUOTES, 'utf-8')]);
             }
             $logsCollection->push([
                 'author_name' => ($log->author) ? $log->author->name : $log->author_name,

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -19,6 +19,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\SanitizeInput::class,
     ];
 
     /**

--- a/app/Http/Middleware/SanitizeInput.php
+++ b/app/Http/Middleware/SanitizeInput.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\TransformsRequest as Middleware;
+
+use Illuminate\Support\Facades\Log;
+
+class SanitizeInput extends Middleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    protected function transform($key, $value)
+    {
+
+        Log::critical($key);
+
+        if (in_array($key, $this->except, true)) {
+            return $value;
+        }
+        if (is_string($value) && $value !== '') {
+            $value = strip_tags($value);
+            $value = htmlentities($value, ENT_QUOTES, 'utf-8');
+        }
+        return $value;
+    }
+
+    /**
+     * The names of the attributes that should not be trimmed.
+     *
+     * @var array
+     */
+    protected $except = [
+        'password',
+        'password_confirmation',
+        '_token',
+        ''
+    ];
+
+}
+

--- a/app/Http/Middleware/SanitizeInput.php
+++ b/app/Http/Middleware/SanitizeInput.php
@@ -4,25 +4,20 @@ namespace App\Http\Middleware;
 
 use Illuminate\Foundation\Http\Middleware\TransformsRequest as Middleware;
 
-use Illuminate\Support\Facades\Log;
-
 class SanitizeInput extends Middleware
 {
     /**
-     * Handle an incoming request.
+     * Extends TransformsRequest to clean input from XSS
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @return mixed
      */
     protected function transform($key, $value)
     {
-
-        Log::critical($key);
-
+        // Ignore excepted ones
         if (in_array($key, $this->except, true)) {
             return $value;
         }
+
+        // Strip Html tags and encode missed ones
         if (is_string($value) && $value !== '') {
             $value = strip_tags($value);
             $value = htmlentities($value, ENT_QUOTES, 'utf-8');

--- a/resources/views/people/introductions/index.blade.php
+++ b/resources/views/people/introductions/index.blade.php
@@ -13,7 +13,7 @@
       @if ($introducer = $contact->getIntroducer())
       <li>
         <i class="fa fa-sign-language"></i>
-        {!! trans('people.introductions_met_through', ['url' => route('people.show', $introducer), 'name' => $introducer->name]) !!}
+        {!! trans('people.introductions_met_through', ['url' => route('people.show', $introducer), 'name' => htmlentities($introducer->name, ENT_QUOTES, 'utf-8')]) !!}
       </li>
       @endif
 


### PR DESCRIPTION
###   Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/2-other-monica

### ⚙️ Description *

XSS queries being triggered from people info page by the audit log at the settings, fix sanitizes content before showing to user.

###   Technical Description *

Even tough Laravel has inbuilt protection for XSS it has been disabled when presenting log: `{!! $log['description'] !!}` to enable embeding contact links, leading to XSS, htmlentities was used to sanitize data before showing to user, efectively avoiding new as well as already stored XSS.

### Edit

Looking further into the code I realized the XSS protection have been disabled in many views so I added a Middleware that will strip html tags using `strip_tags`, and since `strip_tags` can be tricked with malformed markup reamaning input is encoded using htmlentities.

Middleware is at app/Http/Middleware/SanitizeInput.php and can be tunned for specific keys adding them to the `$except` array:
```
    /**
     * The names of the attributes that should not be trimmed.
     *
     * @var array
     */
    protected $except = [
        'password',
        'password_confirmation',
        '_token',
        ''
    ];
```
###   Proof of Concept (PoC) *

1. Download and setup monica
2. Create new contact, introducing payload as name:
`< <svg/onload=alert("firstname1")><script> alert("firstname2_xss")</script> <script> alert("midname_xss")</script> <script> alert("Lname_xss")</script><svg/onload=alert(1)> (<svg/onload=alert("nickie1")>)
`
3. Go to Settings -> Audit logs
4. XSS is triggerd

![Captura de pantalla de 2020-09-24 11-17-57](https://user-images.githubusercontent.com/7505980/94119506-b0338e00-fe57-11ea-8f84-f2e498f493c9.png)

###   Proof of Fix (PoF) *

After fix introduced data is displayed as text and no XSS is executed

![Captura de pantalla de 2020-09-24 11-06-30](https://user-images.githubusercontent.com/7505980/94118602-72823580-fe56-11ea-907c-a74b038a2892.png)

Stored XSS will be also stripped out and encoded after contact is edited

![Captura de pantalla de 2020-09-24 17-53-09](https://user-images.githubusercontent.com/7505980/94162038-f5bf7d80-fe8e-11ea-804b-1be133b9f98f.png)


###   User Acceptance Testing (UAT)

Functionallity is unafected, contact link works as usual
![Captura de pantalla de 2020-09-24 11-35-33](https://user-images.githubusercontent.com/7505980/94121742-6009fb00-fe5a-11ea-877c-29fe73690ffa.png)
